### PR TITLE
Use config name instead of Cardinal

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Finally, to start the virtual Onvif devices run:
 node main.js ./config.yaml
 ```
 
-Your Virtual Onvif Devices should now automatically show up for adoption in Unifi Protect as "Onvif Cardinal" device. The username and password are the same as on the real Onvif device.
+Your Virtual Onvif Devices should now automatically show up for adoption in Unifi Protect as the name specified in the config. The username and password are the same as on the real Onvif device.
 
 
 # Docker

--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -268,7 +268,7 @@ class OnvifServer {
                     GetDeviceInformation: (args) => {
                         return {
                             Manufacturer: 'Onvif',
-                            Model: 'Cardinal',
+                            Model: `${this.config.name}`,
                             FirmwareVersion: '1.0.0',
                             SerialNumber: `${this.config.name.replace(' ', '_')}-0000`,
                             HardwareId: `${this.config.name.replace(' ', '_')}-1001`
@@ -408,7 +408,7 @@ class OnvifServer {
                                             onvif://www.onvif.org/type/video_encoder
                                             onvif://www.onvif.org/type/ptz
                                             onvif://www.onvif.org/hardware/Onvif
-                                            onvif://www.onvif.org/name/Cardinal
+                                            onvif://www.onvif.org/name/${this.config.name}
                                             onvif://www.onvif.org/location/
                                         </d:Scopes>
                                         <d:XAddrs>http://${this.config.hostname}:${this.config.ports.server}/onvif/device_service</d:XAddrs>


### PR DESCRIPTION
Resolves Issue https://github.com/daniela-hase/onvif-server/issues/4

![image](https://github.com/user-attachments/assets/17c9169f-8b83-46b9-9143-4aacd755ca49)

```
onvif:
  - mac: aa:aa:aa:aa:aa:a1
    ports:
      server: 8081
      rtsp: 8554
      snapshot: 8580
    name: Bullet1 
    uuid: ae426b06-36aa-4c89-84fb-7a6eb15ff734
    highQuality:
      rtsp: /Streaming/Channels/101/
      snapshot: /ISAPI/Streaming/Channels/101/picture
      width: 2048
      height: 1536
      framerate: 10
      bitrate: 3072
      quality: 4
    target:
      hostname: 192.168.1.187
      ports:
        rtsp: 554
        snapshot: 80
```