### PR TITLE
For some reason ODM  types are objects? 

### DIFF
--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -385,6 +385,9 @@ class OnvifServer {
                 } catch (err) {
                     probeType = '';
                 }
+
+                if (typeof probeType === 'object')
+                    probeType = probeType._;
             
                 if (probeType === '' || probeType.indexOf('NetworkVideoTransmitter') > -1) {
                     let response = 


### PR DESCRIPTION
This fixes issue https://github.com/daniela-hase/onvif-server/issues/5

The response is parsed as an object with an underscore as the string. 
This prevents this crashing

![image](https://github.com/user-attachments/assets/4149b4e3-9d41-488a-94e5-69af462cc8e8)
