### PR TITLE
Use logger standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "email": "daniela@koshigaya.de"
   },
   "dependencies": {
-    "soap": "1.1.5",
-    "xml2js": "0.4.23",
+    "argparse": "2.0.1",
     "node-tcp-proxy": "0.0.28",
     "node-uuid": "1.4.8",
-    "argparse": "2.0.1",
+    "simple-node-logger": "^21.8.12",
+    "soap": "1.1.5",
+    "xml2js": "0.4.23",
     "yaml": "2.5.1"
   }
 }


### PR DESCRIPTION
I don't know the best package for logging in standard JS projects, but I know to use logger.info(), logger.debug(), logger.error() is standard in all logging frameworks across languages.

Simple.Logger showed up as the most lightweight library to log to console.

So I replaced the console logs with appropriate logger levels, which means that if the package needs to be changed or something else happens later, it won't affect the code logger levels again.

I added some tracing around the network loop as I struggled to understand why it wasn't finding the IP address for MAC

Refers to issues https://github.com/daniela-hase/onvif-server/issues/2 and https://github.com/daniela-hase/onvif-server/issues/3

```
19:51:37.279 DEBUG DeviceService: GetServices
19:51:37.356 DEBUG MediaService: GetProfiles
19:51:37.361 DEBUG MediaService: GetVideoSources
19:51:38.783 DEBUG DeviceService: GetSystemDateAndTime
19:51:38.797 DEBUG DeviceService: GetServices
19:51:38.816 DEBUG MediaService: GetProfiles
19:51:38.819 DEBUG MediaService: GetVideoSources
19:51:38.837 DEBUG DeviceService: GetDeviceInformation
19:51:38.854 DEBUG MediaService: GetSnapshotUri
19:51:39.247 DEBUG MediaService: GetStreamUri
19:51:45.905 DEBUG DeviceService: GetSystemDateAndTime
19:51:45.925 DEBUG DeviceService: GetServices
19:51:45.946 DEBUG MediaService: GetProfiles
19:51:45.949 DEBUG MediaService: GetVideoSources
19:51:45.973 DEBUG DeviceService: GetDeviceInformation
19:51:45.995 DEBUG MediaService: GetSnapshotUri
19:51:46.021 DEBUG MediaService: GetStreamUri
```