### PR TITLE
Fix Exception when creating config with non default port

### DIFF
--- a/src/config-builder.js
+++ b/src/config-builder.js
@@ -21,7 +21,7 @@ async function createConfig(hostname, username, password) {
 
     let hostport = 80;
     if (hostname.indexOf(':') > -1) {
-        hostport = hostname.substr(hostname.indexOf(':') + 1).parseInt();
+        hostport = parseInt(hostname.substr(hostname.indexOf(':') + 1));
         hostname = hostname.substr(0, hostname.indexOf(':'));
     }
 


### PR DESCRIPTION
When trying to create a config with `node main.js --create-config` using a non default port (e.g. 8000) an exception is thrown, because the `parseInt()` function is not called correctly