### PR TITLE
Run npm install inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM node:22-alpine
 
 ADD . /app
 WORKDIR /app
+RUN npm install
 
 ENTRYPOINT node main.js /onvif.yaml


### PR DESCRIPTION
Make dependencies available inside container (else you have to manually run `npm install` when container is created).