### PR TITLE
Fix issue where probeUuid may be parsed as an object & adding mac address to startup logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -90,7 +90,7 @@ if (args) {
         for (let onvifConfig of config.onvif) {
             let server = onvifServer.createServer(onvifConfig, logger);
             if (server.getHostname()) {
-                logger.info(`Starting virtual onvif server for ${onvifConfig.name} on ${server.getHostname()}:${onvifConfig.ports.server} ...`);
+                logger.info(`Starting virtual onvif server for ${onvifConfig.name} on ${onvifConfig.mac} ${server.getHostname()}:${onvifConfig.ports.server} ...`);
                 server.startServer();
                 server.startDiscovery();
                 if (args.debug)

--- a/src/onvif-server.js
+++ b/src/onvif-server.js
@@ -391,6 +391,9 @@ class OnvifServer {
                 if (typeof probeType === 'object')
                     probeType = probeType._;
             
+                if (typeof probeUuid === 'object')
+                    probeUuid = probeUuid._;
+
                 if (probeType === '' || probeType.indexOf('NetworkVideoTransmitter') > -1) {
                     let response = 
                        `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
When the probeUuid is parsed as on object, the response <wsa:RelatesTo> parameter is not correct. Then the unifi server will work intermittently. We also saw it get the raspberrypi main mac address and not the virtual one assigned. This fix resolved our issues.